### PR TITLE
增加获取表前缀静态方法

### DIFF
--- a/src/Db.php
+++ b/src/Db.php
@@ -38,6 +38,7 @@ use Psr\Container\ContainerInterface;
  * @method static rollBack()
  * @method static commit()
  * @method static int transactionLevel()
+ * @method static string getTablePrefix()
  * @method static array pretend(\Closure $callback)
  * @method static ConnectionInterface connection(string $pool)
  */


### PR DESCRIPTION
在使用Db::raw() 里会用到